### PR TITLE
Fix product details liquid bugs

### DIFF
--- a/blocks/product_details.liquid
+++ b/blocks/product_details.liquid
@@ -35,6 +35,12 @@
     --lg-border: hsla(0,0%,100%,.22);
     --lg-shadow: rgba(0,0,0,.25);
     --messages-blue: #007AFF;
+    /* New scoped variables */
+    --mortise-bg: {% if block.settings.mortise_chip_background != blank %}{{ block.settings.mortise_chip_background }}{% else %}var(--chip-bg){% endif %};
+    --mortise-text: {% if block.settings.mortise_chip_text_color != blank %}{{ block.settings.mortise_chip_text_color }}{% else %}var(--chip-text){% endif %};
+    --buy-now-bg: {% if block.settings.buy_now_background != blank %}{{ block.settings.buy_now_background }}{% else %}#007AFF{% endif %};
+    --buy-now-text: {% if block.settings.buy_now_text_color != blank %}{{ block.settings.buy_now_text_color }}{% else %}#ffffff{% endif %};
+    --buy-now-hover: {% if block.settings.buy_now_hover_background != blank %}{{ block.settings.buy_now_hover_background }}{% else %}#0056CC{% endif %};
   }
 
   @media (prefers-reduced-motion: reduce) {
@@ -127,11 +133,19 @@
     transition: transform 0.6s cubic-bezier(0.25, 0.46, 0.45, 0.94);
   }
 
-  .broen-hero__media-item-{{ section_id }}:hover .broen-hero__media-content-{{ section_id }} {
+  .broen-hero__media-item-{{ section_id }}:hover img.broen-hero__media-content-{{ section_id }} {
     transform: scale(1.02);
   }
 
+  /* Optimize video placement and disable hover interaction */
+  .broen-hero__media-{{ section_id }} video.broen-hero__media-content-{{ section_id }} {
+    object-fit: cover;
+    width: 100%;
+    height: 100%;
+    pointer-events: none;
+  }
 
+  
 
   .broen-hero__placeholder-{{ section_id }} {
     font-size: 64px;
@@ -349,8 +363,8 @@
   }
 
   .broen-hero__mortise-{{ section_id }} {
-    background: var(--chip-bg);
-    color: var(--chip-text);
+    background: var(--mortise-bg);
+    color: var(--mortise-text);
     border: 1px solid var(--border);
     border-radius: 100px;
     padding: 12px 20px;
@@ -467,7 +481,7 @@
     letter-spacing: -0.01em;
     font-size: 16px;
     line-height: 1;
-    color: #ffffff;
+    color: var(--buy-now-text);
 
     display: inline-flex;
     align-items: center;
@@ -480,14 +494,14 @@
     border-radius: 100px;
     border: none;
 
-    background: var(--messages-blue);
+    background: var(--buy-now-bg);
     box-shadow: 0 4px 16px rgba(0, 122, 255, 0.3);
 
     transition: all 0.2s ease;
   }
 
   .broen-hero__buy-now-{{ section_id }}:hover:not(:disabled) {
-    background: #0056CC;
+    background: var(--buy-now-hover);
     transform: translateY(-1px);
     box-shadow: 0 8px 24px rgba(0, 122, 255, 0.4);
   }
@@ -792,6 +806,7 @@
   const variants = {{ product.variants | json }};
   const colorOptionIndex = {{ color_option_index | json }};
   const mortiseOptionIndex = {{ mortise_option_index | json }};
+  const colorValues = {{ color_values | json }};
   
   // Media mapping
   const heroVideoUrl = {{ product.metafields.custom.hero_video.value | default: product.metafields.custom.hero_video | json }};
@@ -876,7 +891,10 @@
       video.muted = true;
       video.loop = true;
       video.playsInline = true;
-      video.loading = 'lazy';
+      video.setAttribute('playsinline', '');
+      video.autoplay = true;
+      video.setAttribute('autoplay', '');
+      video.preload = 'metadata';
       if (media.poster) video.poster = media.poster;
       
       const source = document.createElement('source');
@@ -895,6 +913,28 @@
     }
 
     return slide;
+  }
+
+  function shouldIncludeMedia(media) {
+    // Only include images here; videos are handled via heroVideoUrl
+    if (media.type === 'video') return false;
+    // Skip duplicate of current variant featured image
+    if (currentVariant && currentVariant.featured_media && media.id === currentVariant.featured_media.id) return false;
+
+    const alt = (media.alt || '').toLowerCase();
+    const sel = (selectedColor || '').toLowerCase();
+
+    // If we have color values, exclude media that clearly references other colors
+    if (Array.isArray(colorValues) && colorValues.length > 0) {
+      const mentionsAnyColor = colorValues.some(cv => alt.includes(String(cv).toLowerCase()));
+      if (mentionsAnyColor) {
+        // Include only if it mentions the selected color
+        return sel ? alt.includes(sel) : false;
+      }
+    }
+
+    // Media without color mentions is considered generic and included
+    return true;
   }
 
   function rebuildCarousel() {
@@ -929,9 +969,9 @@
       usedMediaIds.add('hero-video');
     }
 
-    // 3. Add remaining product media
+    // 3. Add remaining product media (images only; filter out other variant images)
     productMedia.forEach(media => {
-      if (!usedMediaIds.has(media.id)) {
+      if (!usedMediaIds.has(media.id) && shouldIncludeMedia(media)) {
         slides.push(createMediaSlide(media));
         usedMediaIds.add(media.id);
       }
@@ -957,6 +997,10 @@
     currentSlide = 0;
 
     setupCarouselNavigation();
+    if (carouselWrapper) {
+      carouselWrapper.classList.toggle('single-slide', totalSlides < 2);
+    }
+    manageVideoPlayback();
   }
 
   function setupCarouselNavigation() {
@@ -1007,6 +1051,9 @@
       document.querySelectorAll(`.broen-hero__dot-${sectionId}`).forEach((dot, i) => {
         dot.classList.toggle('active', i === index);
       });
+
+      // Manage video playback based on active slide
+      manageVideoPlayback();
     }
   }
 
@@ -1271,6 +1318,8 @@
           document.querySelectorAll(`.broen-hero__dot-${sectionId}`).forEach((dot, i) => {
             dot.classList.toggle('active', i === currentSlide);
           });
+          // Ensure correct video playback when user scrolls manually
+          manageVideoPlayback();
         }
       }, { passive: true });
       
@@ -1310,6 +1359,20 @@
         }
       });
     }
+  }
+
+  function manageVideoPlayback() {
+    if (!carousel) return;
+    const items = carousel.querySelectorAll(`.broen-hero__media-item-${sectionId}`);
+    items.forEach((item, idx) => {
+      const video = item.querySelector(`video.broen-hero__media-content-${sectionId}`);
+      if (!video) return;
+      if (idx === currentSlide) {
+        try { video.play().catch(() => {}); } catch (e) {}
+      } else {
+        try { video.pause(); video.currentTime = 0; } catch (e) {}
+      }
+    });
   }
 
   function initButtons() {
@@ -1410,6 +1473,7 @@
     initMortiseSelection();
     initCarouselControls();
     initButtons();
+    manageVideoPlayback();
     
     // Debug: Check if buttons exist
     const colorButtons = document.querySelectorAll(`.broen-hero__color-${sectionId}`);
@@ -1524,6 +1588,44 @@
       "id": "dot_inactive_color",
       "label": "Inactive carousel dot",
       "default": "rgba(255, 255, 255, 0.3)"
+    },
+    {
+      "type": "header",
+      "content": "Mortise Appearance"
+    },
+    {
+      "type": "color",
+      "id": "mortise_chip_background",
+      "label": "Mortise chip background",
+      "default": "#222222"
+    },
+    {
+      "type": "color",
+      "id": "mortise_chip_text_color",
+      "label": "Mortise chip text",
+      "default": "#ffffff"
+    },
+    {
+      "type": "header",
+      "content": "Buy Now Button"
+    },
+    {
+      "type": "color",
+      "id": "buy_now_background",
+      "label": "Buy Now background",
+      "default": "#007AFF"
+    },
+    {
+      "type": "color",
+      "id": "buy_now_text_color",
+      "label": "Buy Now text",
+      "default": "#ffffff"
+    },
+    {
+      "type": "color",
+      "id": "buy_now_hover_background",
+      "label": "Buy Now hover background",
+      "default": "#0056CC"
     },
     {
       "type": "header",


### PR DESCRIPTION
Implement separate color controls for mortise chips and the Buy Now button, and resolve multiple bugs in the product gallery related to video playback, variant image display, and variant switching.

The previous gallery had issues where the hero video would not play, variant switching was blocked when the video was active, and the image order was not intuitive. This PR ensures the current variant's image is shown first, followed by the hero video, and then only product images relevant to the selected variant, while also enabling video autoplay and managing playback during carousel navigation and variant changes.

---
<a href="https://cursor.com/background-agent?bcId=bc-7053605a-9ce4-4e65-a434-6ed0b87b8fe2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7053605a-9ce4-4e65-a434-6ed0b87b8fe2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

